### PR TITLE
Feature: add HotKeys and HotStrings to outline

### DIFF
--- a/src/parser/model.ts
+++ b/src/parser/model.ts
@@ -4,6 +4,7 @@ export interface Script {
     methods: Method[];
     refs: Ref[];
     labels: Label[];
+    hotkeys: Hotkey[];
     variables: Variable[];
     blocks: Block[];
 }
@@ -18,6 +19,15 @@ export interface Variable {
 }
 
 export class Label {
+    constructor(
+        public name: string,
+        public document: vscode.TextDocument,
+        public line: number,
+        public character: number,
+    ) {}
+}
+
+export class Hotkey {
     constructor(
         public name: string,
         public document: vscode.TextDocument,

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -177,17 +177,6 @@ export class Parser {
                 return hotkey;
             }
         }
-        // DO NOT SEARCH IN ALL FILES, SCRIPTS CAN HAVE DUPLICATE HOTKEYS!
-        // for (const filePath of this.documentCache.keys()) {
-        //     for (const hotkey of this.documentCache.get(filePath).hotkeys) {
-        //         const hotkeyName = hotkey.name
-        //             .toLowerCase()
-        //             .replace(/^:.*?:/, '');
-        //         if (hotkeyName === name) {
-        //             return hotkey;
-        //         }
-        //     }
-        // }
     }
 
     public static async getLabelByName(

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -247,9 +247,11 @@ export class Parser {
     }
 
     private static getLabelByLine(document: vscode.TextDocument, line: number) {
-        const text = CodeUtil.purify(document.lineAt(line).text).trim();
+        const text = CodeUtil.purify(document.lineAt(line).text);
         // [\u4e00-\u9fa5] Chinese unicode characters
-        const label = /^([\u4e00-\u9fa5_a-zA-Z0-9]+):{1}(?!(:|=))/.exec(text);
+        const label = /^[ \t]*([\u4e00-\u9fa5_a-zA-Z0-9]+) *:{1}(?!(:|=))/.exec(
+            text,
+        );
         if (label) {
             const labelName = label[1];
             if (

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -245,9 +245,9 @@ export class Parser {
     ) {
         const text = CodeUtil.purify(document.lineAt(line).text).trim();
         // captures hotkeys and hotstrings
-        const hotkey = /^(.+?)::/.exec(text);
+        const hotkey = /^(.+?)::|hotkey(?:\s|,)\s*(?!\s*if)([^,]+)/i.exec(text);
         if (hotkey) {
-            const hotkeyName = hotkey[1];
+            const hotkeyName = hotkey[1] ?? hotkey[2];
             return new Hotkey(
                 hotkeyName,
                 document,

--- a/src/providers/defProvider.ts
+++ b/src/providers/defProvider.ts
@@ -43,7 +43,7 @@ export class DefProvider implements vscode.DefinitionProvider {
             );
         }
 
-        // "get hotkey" must be below "get label"!
+        // "get hotkey" must be called after "get label"!
         // If label and hotkey has same names, label can be placed only above
         // hotkey (below hotkey will generate error). AutoHotkey's
         // "Goto duplicateLabelName" command will jump to label!

--- a/src/providers/defProvider.ts
+++ b/src/providers/defProvider.ts
@@ -33,13 +33,27 @@ export class DefProvider implements vscode.DefinitionProvider {
             }
         }
 
-        // getlabel
+        // get label
         const label = await Parser.getLabelByName(document, word);
         if (label) {
             const tempDocument = label.document;
             return new vscode.Location(
                 tempDocument.uri,
                 new vscode.Position(label.line, label.character),
+            );
+        }
+
+        // "get hotkey" must be below "get label"!
+        // If label and hotkey has same names, label can be placed only above
+        // hotkey (below hotkey will generate error). AutoHotkey's
+        // "Goto duplicateLabelName" command will jump to label!
+        // So we must "get label" before "get hotkey" location.
+        const hotkey = await Parser.getHotkeyByName(document, word);
+        if (hotkey) {
+            const tempDocument = hotkey.document;
+            return new vscode.Location(
+                tempDocument.uri,
+                new vscode.Position(hotkey.line, hotkey.character),
             );
         }
 

--- a/src/providers/symbolProvider.ts
+++ b/src/providers/symbolProvider.ts
@@ -38,6 +38,20 @@ export class SymbolProvider implements vscode.DocumentSymbolProvider {
             );
         }
 
+        for (const hotkey of script.hotkeys) {
+            result.push(
+                new vscode.SymbolInformation(
+                    hotkey.name,
+                    vscode.SymbolKind.Event,
+                    null,
+                    new vscode.Location(
+                        hotkey.document.uri,
+                        new vscode.Position(hotkey.line, hotkey.character),
+                    ),
+                ),
+            );
+        }
+
         for (const block of script.blocks) {
             result.push(
                 new vscode.SymbolInformation(

--- a/src/test/suite/parser/parser.test.ts
+++ b/src/test/suite/parser/parser.test.ts
@@ -51,6 +51,38 @@ suite('Parser', () => {
                 in: 'F1:: Goto :*:btw', // GoTo HotString :*:btw::
                 hn: 'F1',
             },
+            {
+                in: 'Hotkey If True',
+                hn: '',
+            },
+            {
+                in: 'Hotkey, If True',
+                hn: '',
+            },
+            {
+                in: 'Hotkey IfWinActive, Untitled',
+                hn: '',
+            },
+            {
+                in: 'Hotkey, IfWinActive, Untitled',
+                hn: '',
+            },
+            {
+                in: 'Hotkey F1',
+                hn: 'F1',
+            },
+            {
+                in: 'Hotkey, F1',
+                hn: 'F1',
+            },
+            {
+                in: 'Hotkey F1, Label',
+                hn: 'F1',
+            },
+            {
+                in: 'Hotkey, F1, Label',
+                hn: 'F1',
+            },
         ];
         dataList.forEach((data) => {
             test("'" + data.in + "' => '" + data.hn + "'", async () => {
@@ -60,7 +92,11 @@ suite('Parser', () => {
                 });
                 // Use array access for the private members
                 const hotkey = Parser['getHotkeyByLine'](document, 0);
-                assert.strictEqual(hotkey.name, data.hn);
+                if (data.hn) {
+                    assert.strictEqual(hotkey.name, data.hn);
+                } else {
+                    assert.strictEqual(hotkey, undefined);
+                }
             });
         });
     });

--- a/src/test/suite/parser/parser.test.ts
+++ b/src/test/suite/parser/parser.test.ts
@@ -36,6 +36,35 @@ suite('Parser', () => {
         });
     });
 
+    suite('getHotkeyByLine', () => {
+        // List of test data
+        let dataList = [
+            // {
+            //     in: // input test string
+            //     hn: // hotkey's name
+            // },
+            {
+                in: 'F1:: Goto ::btw', // GoTo HotString ::btw::
+                hn: 'F1',
+            },
+            {
+                in: 'F1:: Goto :*:btw', // GoTo HotString :*:btw::
+                hn: 'F1',
+            },
+        ];
+        dataList.forEach((data) => {
+            test("'" + data.in + "' => '" + data.hn + "'", async () => {
+                const document = await vscode.workspace.openTextDocument({
+                    language: 'ahk',
+                    content: data.in,
+                });
+                // Use array access for the private members
+                const hotkey = Parser['getHotkeyByLine'](document, 0);
+                assert.strictEqual(hotkey.name, data.hn);
+            });
+        });
+    });
+
     suite('getRemarkByLine', () => {
         // List of test data
         let dataList = [


### PR DESCRIPTION
Closes #87.

![Result](https://user-images.githubusercontent.com/964801/215278414-e647311f-9671-4ed6-a18b-6d45fa62a99f.png)

Working `Go to Definition F12` only for one key hotkey and hotstrings without spaces.

Atomic capture `\s*+(?!if)` not work, but this works fine `\s*(?!\s*if)` (exclude `If*` words after `Hotkey` command.

Notifying @mark-wiemer
