### PR TITLE
v4.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ Breaking changes:
 
 Other changes:
 
+-   IntelliSense no longer suggests words when a user presses space ([Issue #110](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/110))
 -   IntelliSense now suggests `foo(p1, p2)` instead of `foo (p1,p2)`
 -   Improved descriptions of settings
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,22 @@
 <!-- PRs -- Find: `#([0-9]+)`, Replace `[PR #$1](https://github.com/vscode-autohotkey/ahkpp/pull/$1)` -->
 <!-- Issues -- Find: `#([0-9]+)`, Replace `[#$1](https://github.com/vscode-autohotkey/ahkpp/issues/$1)` -->
 
+## 4.0.0 - 2023-07-29 🍀
+
+Minimal changes here, just following [semantic versioning](https://semver.org) since there are breaking changes.
+
+Breaking changes:
+
+-   Rename some settings. Users will have to manually adjust these new settings from the defaults to match their old settings:
+    -   `ahk++.formatter.indentCodeAfterSharpDirective` is now `ahk++.formatter.indentCodeAfterIfDirective`
+    -   `ahk++.language.enableIntellisense` is now `ahk++.intellisense.enableIntellisense`
+    -   `ahk++.file.maximumParseLength` is now `ahk++.intellisense.maximumParseLength`
+
+Other changes:
+
+-   IntelliSense now suggests `foo(p1, p2)` instead of `foo (p1,p2)`
+-   Improved descriptions of settings
+
 ## 3.3.3 - 2023-07-27 🏖️
 
 -   Restore changes from 3.3.1. This release is the same as 3.3.1, except the debugger works.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-autohotkey-plus-plus",
-    "version": "3.3.3",
+    "version": "4.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-autohotkey-plus-plus",
-            "version": "3.3.3",
+            "version": "4.0.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-autohotkey-plus-plus",
     "displayName": "AutoHotkey Plus Plus",
-    "version": "3.3.3",
+    "version": "4.0.0",
     "description": "AutoHotkey IntelliSense, debug, and language support for VS Code, forked from AutoHotkey Plus by cweijan",
     "categories": [
         "Programming Languages",


### PR DESCRIPTION
## 4.0.0 - 2023-07-29 🍀

Minimal changes here, just following [semantic versioning](https://semver.org) since there are breaking changes.

Breaking changes:

-   Rename some settings. Users will have to manually adjust these new settings from the defaults to match their old settings:
    -   `ahk++.formatter.indentCodeAfterSharpDirective` is now `ahk++.formatter.indentCodeAfterIfDirective`
    -   `ahk++.language.enableIntellisense` is now `ahk++.intellisense.enableIntellisense`
    -   `ahk++.file.maximumParseLength` is now `ahk++.intellisense.maximumParseLength`

Other changes:

-   IntelliSense no longer suggests words when a user presses space ([Issue #110](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/110))
-   IntelliSense now suggests `foo(p1, p2)` instead of `foo (p1,p2)`
-   Improved descriptions of settings