### PR TITLE
Add formatting test

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,30 +21,6 @@
             ],
             "outFiles": ["${workspaceFolder}/out/test/**/*.js"],
             "preLaunchTask": "npm: compile"
-        },
-        // TODO untested
-        {
-            "type": "ahk",
-            "request": "launch",
-            "name": "Autohotkey v1 Debugger",
-            "program": "${workspaceFolder}/demos/v1Demo.ahk",
-            "runtime": "C:\\Program Files\\Autohotkey\\AutoHotkeyU64.exe",
-            "stopOnEntry": false,
-            "dbgpSettings": {
-                "max_children": 149
-            }
-        },
-        // TODO untested
-        {
-            "type": "ahk2",
-            "request": "launch",
-            "name": "Autohotkey v2 Debugger",
-            "program": "${workspaceFolder}/demos/v2Demo.ahk",
-            "runtime": "C:\\Program Files\\AutoHotkey\\v2-alpha\\x64\\AutoHotkey.exe", // Default value of Scite for ahk v2
-            "stopOnEntry": false,
-            "dbgpSettings": {
-                "max_children": 149
-            }
         }
     ]
 }

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 
 -   `ahk++.file.interpreterPathV2` now defaults to `C:/Program Files/AutoHotkey/v2/AutoHotkey64.exe` ([Issue #387](https://github.com/mark-wiemer-org/ahkpp/issues/387))
 -   Add breakpoint support for AHK v2 files ([Issue #384](https://github.com/mark-wiemer-org/ahkpp/issues/384))
+-   Add AHK v2 debug config template ([#385](https://github.com/mark-wiemer-org/ahkpp/issues/385))
 
 ## 5.0.0 - 2023-08-07 ✌️
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,10 @@
 <!-- PRs -- Find: `#([0-9]+)`, Replace `[PR #$1](https://github.com/vscode-autohotkey/ahkpp/pull/$1)` -->
 <!-- Issues -- Find: `#([0-9]+)`, Replace `[#$1](https://github.com/vscode-autohotkey/ahkpp/issues/$1)` -->
 
+## 5.0.1 - 2023-08-08 😶‍🌫️
+
+-   `ahk++.file.interpreterPathV2` now defaults to `C:/Program Files/AutoHotkey/v2/AutoHotkey64.exe` ([Issue #387](https://github.com/mark-wiemer-org/ahkpp/issues/387))
+
 ## 5.0.0 - 2023-08-07 ✌️
 
 AutoHotkey v2 support now in preview! Please test it out and [report any issues](https://github.com/mark-wiemer-org/ahkpp/issues/new?assignees=mark-wiemer&labels=AHK+v2&projects=&template=v2.md&title=%5Bv2%5D+), you'll help the community of 120,000+ users of this extension!

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 ## 5.0.1 - 2023-08-08 😶‍🌫️
 
 -   `ahk++.file.interpreterPathV2` now defaults to `C:/Program Files/AutoHotkey/v2/AutoHotkey64.exe` ([Issue #387](https://github.com/mark-wiemer-org/ahkpp/issues/387))
+-   Add breakpoint support for AHK v2 files ([Issue #384](https://github.com/mark-wiemer-org/ahkpp/issues/384))
 
 ## 5.0.0 - 2023-08-07 ✌️
 

--- a/demos/manualTests/formatting.ahk
+++ b/demos/manualTests/formatting.ahk
@@ -1,0 +1,2 @@
+; Shift+Alt+F to format
+ ExitApp

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "@typescript-eslint/eslint-plugin": "^5.37.0",
                 "@typescript-eslint/parser": "^5.37.0",
                 "@vscode/test-electron": "^1.6.1",
-                "@vscode/vsce": "^2.19.0",
+                "@vscode/vsce": "^2.20.1",
                 "chai": "^4.3.7",
                 "esbuild": "^0.15.7",
                 "esbuild-plugin-eslint": "^0.1.1",
@@ -494,9 +494,9 @@
             }
         },
         "node_modules/@vscode/vsce": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.19.0.tgz",
-            "integrity": "sha512-dAlILxC5ggOutcvJY24jxz913wimGiUrHaPkk16Gm9/PGFbz1YezWtrXsTKUtJws4fIlpX2UIlVlVESWq8lkfQ==",
+            "version": "2.20.1",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.20.1.tgz",
+            "integrity": "sha512-ilbvoqvR/1/zseRPBAzYR6aKqSJ+jvda4/BqIwOqTxajpvLtEpK3kMLs77+dJdrlygS+VrP7Yhad8j0ukyD96g==",
             "dev": true,
             "dependencies": {
                 "azure-devops-node-api": "^11.0.1",
@@ -512,7 +512,7 @@
                 "minimatch": "^3.0.3",
                 "parse-semver": "^1.1.1",
                 "read": "^1.0.7",
-                "semver": "^5.1.0",
+                "semver": "^7.5.2",
                 "tmp": "^0.2.1",
                 "typed-rest-client": "^1.8.4",
                 "url-join": "^4.0.1",
@@ -596,15 +596,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver"
             }
         },
         "node_modules/@vscode/vsce/node_modules/supports-color": {
@@ -4120,9 +4111,9 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "node_modules/semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -5251,9 +5242,9 @@
             }
         },
         "@vscode/vsce": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.19.0.tgz",
-            "integrity": "sha512-dAlILxC5ggOutcvJY24jxz913wimGiUrHaPkk16Gm9/PGFbz1YezWtrXsTKUtJws4fIlpX2UIlVlVESWq8lkfQ==",
+            "version": "2.20.1",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.20.1.tgz",
+            "integrity": "sha512-ilbvoqvR/1/zseRPBAzYR6aKqSJ+jvda4/BqIwOqTxajpvLtEpK3kMLs77+dJdrlygS+VrP7Yhad8j0ukyD96g==",
             "dev": true,
             "requires": {
                 "azure-devops-node-api": "^11.0.1",
@@ -5270,7 +5261,7 @@
                 "minimatch": "^3.0.3",
                 "parse-semver": "^1.1.1",
                 "read": "^1.0.7",
-                "semver": "^5.1.0",
+                "semver": "^7.5.2",
                 "tmp": "^0.2.1",
                 "typed-rest-client": "^1.8.4",
                 "url-join": "^4.0.1",
@@ -5330,12 +5321,6 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
                     "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
                 },
                 "supports-color": {
@@ -7824,9 +7809,9 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "requires": {
                 "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
                 },
                 "ahk++.file.interpreterPathV2": {
                     "type": "string",
-                    "default": "C:/Program Files/AutoHotkey/AutoHotkeyU64.exe",
+                    "default": "C:/Program Files/AutoHotkey/v2/AutoHotkey64.exe",
                     "description": "Path to the AHK v2 interpreter."
                 },
                 "ahk++.file.helpPathV1": {

--- a/package.json
+++ b/package.json
@@ -424,7 +424,7 @@
         "@typescript-eslint/eslint-plugin": "^5.37.0",
         "@typescript-eslint/parser": "^5.37.0",
         "@vscode/test-electron": "^1.6.1",
-        "@vscode/vsce": "^2.19.0",
+        "@vscode/vsce": "^2.20.1",
         "chai": "^4.3.7",
         "esbuild": "^0.15.7",
         "esbuild-plugin-eslint": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
         "breakpoints": [
             {
                 "language": "ahk"
+            },
+            {
+                "language": "ahk2"
             }
         ],
         "commands": [

--- a/package.json
+++ b/package.json
@@ -204,7 +204,10 @@
         "debuggers": [
             {
                 "type": "ahk",
-                "label": "AutoHotkey",
+                "label": "AutoHotkey v1",
+                "languages": [
+                    "ahk"
+                ],
                 "program": "./out/debugger/DebugAdapter.js",
                 "runtime": "\"C:\\Program Files\\AutoHotkey\\AutoHotkeyU64.exe\"",
                 "configurationAttributes": {
@@ -215,12 +218,12 @@
                         "properties": {
                             "program": {
                                 "type": "string",
-                                "description": "Absolute path to a text file.",
+                                "description": "Absolute path to the AHK v1 script to debug.",
                                 "default": "${file}"
                             },
                             "runtime": {
                                 "type": "string",
-                                "description": "Absolute path to a AutoHotkey.exe file.",
+                                "description": "Absolute path to an AutoHotkey v1 interpreter.",
                                 "default": "C:\\Program Files\\AutoHotkey\\AutoHotkeyU64.exe"
                             },
                             "stopOnEntry": {
@@ -238,16 +241,16 @@
                                 "properties": {
                                     "max_children": {
                                         "type": "integer",
-                                        "description": "max number of array or object children to initially retrieve",
+                                        "description": "Max number of array or object children to initially retrieve.",
                                         "default": 300
                                     },
                                     "max_data": {
                                         "type": "integer",
-                                        "description": "max amount of variable data to initially retrieve.",
+                                        "description": "Max amount of variable data to initially retrieve.",
                                         "default": 131072
                                     }
                                 },
-                                "description": "Dbgp settings. See https://xdebug.org/docs-dbgp.php#feature-names",
+                                "description": "DBGP settings. See https://xdebug.org/docs-dbgp.php#feature-names",
                                 "default": {}
                             }
                         }
@@ -257,18 +260,94 @@
                     {
                         "type": "ahk",
                         "request": "launch",
-                        "name": "AutoHotkey Debugger",
+                        "name": "AutoHotkey v1 Debugger",
                         "program": "${file}",
                         "stopOnEntry": true
                     }
                 ],
                 "configurationSnippets": [
                     {
-                        "label": "AutoHotkey Debug: Launch",
+                        "label": "AutoHotkey v1 Debug: Launch",
                         "body": {
                             "type": "ahk",
                             "request": "launch",
-                            "name": "AutoHotkey Debugger",
+                            "name": "AutoHotkey v1 Debugger",
+                            "program": "${file}",
+                            "stopOnEntry": true
+                        }
+                    }
+                ]
+            },
+            {
+                "type": "ahk2",
+                "label": "AutoHotkey v2",
+                "languages": [
+                    "ahk2"
+                ],
+                "program": "./out/debugger/DebugAdapter.js",
+                "runtime": "\"C:\\Program Files\\AutoHotkey\\v2\\AutoHotkey64.exe\"",
+                "configurationAttributes": {
+                    "launch": {
+                        "required": [
+                            "program"
+                        ],
+                        "properties": {
+                            "program": {
+                                "type": "string",
+                                "description": "Absolute path to the AHK v2 script to debug.",
+                                "default": "${file}"
+                            },
+                            "runtime": {
+                                "type": "string",
+                                "description": "Absolute path to an AutoHotkey v2 interpreter.",
+                                "default": "C:\\Program Files\\AutoHotkey\\v2\\AutoHotkey64.exe"
+                            },
+                            "stopOnEntry": {
+                                "type": "boolean",
+                                "description": "Automatically stop after launch.",
+                                "default": true
+                            },
+                            "trace": {
+                                "type": "boolean",
+                                "description": "Enable logging of the Debug Adapter Protocol.",
+                                "default": true
+                            },
+                            "dbgpSettings": {
+                                "type": "object",
+                                "properties": {
+                                    "max_children": {
+                                        "type": "integer",
+                                        "description": "Max number of array or object children to initially retrieve.",
+                                        "default": 300
+                                    },
+                                    "max_data": {
+                                        "type": "integer",
+                                        "description": "Max amount of variable data to initially retrieve.",
+                                        "default": 131072
+                                    }
+                                },
+                                "description": "DBGP settings. See https://xdebug.org/docs-dbgp.php#feature-names",
+                                "default": {}
+                            }
+                        }
+                    }
+                },
+                "initialConfigurations": [
+                    {
+                        "type": "ahk2",
+                        "request": "launch",
+                        "name": "AutoHotkey v2 Debugger",
+                        "program": "${file}",
+                        "stopOnEntry": true
+                    }
+                ],
+                "configurationSnippets": [
+                    {
+                        "label": "AutoHotkey v2 Debug: Launch",
+                        "body": {
+                            "type": "ahk2",
+                            "request": "launch",
+                            "name": "AutoHotkey v2 Debugger",
                             "program": "${file}",
                             "stopOnEntry": true
                         }


### PR DESCRIPTION
Closes #387, #384, #385.

Changes proposed in this pull request:

-   `ahk++.file.interpreterPathV2` now defaults to `C:/Program Files/AutoHotkey/v2/AutoHotkey64.exe` ([Issue #387](https://github.com/mark-wiemer-org/ahkpp/issues/387))
-   Add breakpoint support for AHK v2 files ([Issue #384](https://github.com/mark-wiemer-org/ahkpp/issues/384))
-   Add AHK v2 debug config template ([#385](https://github.com/mark-wiemer-org/ahkpp/issues/385))
