### PR TITLE
v5.0.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,5 @@
 # Changelog
 
-<!-- PRs -- Find: `#([0-9]+)`, Replace `[PR #$1](https://github.com/vscode-autohotkey/ahkpp/pull/$1)` -->
-<!-- Issues -- Find: `#([0-9]+)`, Replace `[#$1](https://github.com/vscode-autohotkey/ahkpp/issues/$1)` -->
-
 ## 5.0.1 - 2023-08-08 😶‍🌫️
 
 -   `ahk++.file.interpreterPathV2` now defaults to `C:/Program Files/AutoHotkey/v2/AutoHotkey64.exe` ([Issue #387](https://github.com/mark-wiemer-org/ahkpp/issues/387))

--- a/Changelog.md
+++ b/Changelog.md
@@ -51,7 +51,7 @@ This update relies heavily on open-source code from [thqby](https://github.com/t
 
 -   Add quick help, adapted from thqby's AutoHotkey v2 Language Support
     -   Selected text (or word at cursor) is now searched within the help documentation
-    -   Known limitation: if selected text would cause a syntax error when injected into a script, help is activated but no search is made. Ref [issue #376](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/376)
+    -   Known limitation: if selected text would cause a syntax error when injected into a script, help is activated but no search is made. [Issue #376](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/376)
 -   Update file icon to match [official AHK repository](https://github.com/AutoHotkey/AutoHotkey/blob/446829bc730aa002635d3d36bfd17e892b6981c0/source/resources/icons.svg)
 
 ## 4.0.0 - 2023-07-29 🍀

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@
 
 -   `ahk++.file.interpreterPathV2` now defaults to `C:/Program Files/AutoHotkey/v2/AutoHotkey64.exe` ([Issue #387](https://github.com/mark-wiemer-org/ahkpp/issues/387))
 -   Add breakpoint support for AHK v2 files ([Issue #384](https://github.com/mark-wiemer-org/ahkpp/issues/384))
--   Add AHK v2 debug config template ([#385](https://github.com/mark-wiemer-org/ahkpp/issues/385))
+-   Add AHK v2 debug config template ([Issue #385](https://github.com/mark-wiemer-org/ahkpp/issues/385))
 
 ## 5.0.0 - 2023-08-07 ✌️
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-autohotkey-plus-plus",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-autohotkey-plus-plus",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-autohotkey-plus-plus",
     "displayName": "AutoHotkey Plus Plus",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "description": "AutoHotkey v1 and v2 language support for Visual Studio Code: IntelliSense, debugging, formatting, and more",
     "categories": [
         "Programming Languages",


### PR DESCRIPTION
## 5.0.1 - 2023-08-08 😶‍🌫️

-   `ahk++.file.interpreterPathV2` now defaults to `C:/Program Files/AutoHotkey/v2/AutoHotkey64.exe` ([Issue #387](https://github.com/mark-wiemer-org/ahkpp/issues/387))
-   Add breakpoint support for AHK v2 files ([Issue #384](https://github.com/mark-wiemer-org/ahkpp/issues/384))
-   Add AHK v2 debug config template ([Issue #385](https://github.com/mark-wiemer-org/ahkpp/issues/385))