### PR TITLE
v5.0.2 - Fix language mode resetting when VS Code restarts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.2 - 2023-08-10 🐈
+
+-   Fix language mode resetting when VS Code restarts ([Issue #392](https://github.com/mark-wiemer-org/ahkpp/issues/392))
+
 ## 5.0.1 - 2023-08-08 😶‍🌫️
 
 -   `ahk++.file.interpreterPathV2` now defaults to `C:/Program Files/AutoHotkey/v2/AutoHotkey64.exe` ([Issue #387](https://github.com/mark-wiemer-org/ahkpp/issues/387))

--- a/demos/manualTests/folding.ahk
+++ b/demos/manualTests/folding.ahk
@@ -1,3 +1,4 @@
+#Requires AutoHotkey v1
 /*
     I'm collapsible!
 */

--- a/demos/manualTests/formatting.ahk
+++ b/demos/manualTests/formatting.ahk
@@ -1,2 +1,4 @@
+#Requires AutoHotkey v1
+
 ; Shift+Alt+F to format
  ExitApp

--- a/demos/manualTests/hover.ahk
+++ b/demos/manualTests/hover.ahk
@@ -1,3 +1,5 @@
+#Requires AutoHotkey v1
+
 ; I show up in IntelliSense when hovering only when parsing is enabled
 hoverOverMePlease()
 {

--- a/demos/manualTests/languageVersion/1.ahk
+++ b/demos/manualTests/languageVersion/1.ahk
@@ -1,0 +1,7 @@
+; Open both 1.ahk and 2.ahk in the same editor group
+; Set file association for .ahk to AHK v2
+; Reload window
+; File associations will start AHK v2 (green icon), then update to AHK v1 (blue icon)
+
+#Requires AutoHotkey v1
+

--- a/demos/manualTests/languageVersion/2.ahk
+++ b/demos/manualTests/languageVersion/2.ahk
@@ -1,0 +1,7 @@
+; Open both 1.ahk and 2.ahk in the same editor group
+; Set file association for .ahk to AHK v2
+; Reload window
+; File associations will start AHK v2 (green icon), then update to AHK v1 (blue icon)
+
+#Requires AutoHotkey v1
+

--- a/demos/v1Demo.ahk
+++ b/demos/v1Demo.ahk
@@ -1,4 +1,6 @@
-﻿globalVar := "Global"
+﻿#Requires AutoHotkey v1
+
+globalVar := "Global"
 global SuperGlobalVar := "SuperGlobal"
 function()
 return

--- a/demos/v2Demo.ahk2
+++ b/demos/v2Demo.ahk2
@@ -1,4 +1,6 @@
-﻿#HotIf WinActive("ahk_class Notepad") or WinActive(MyWindowTitle)
+﻿#Requires AutoHotkey v2
+
+#HotIf WinActive("ahk_class Notepad") or WinActive(MyWindowTitle)
 #Space::MsgBox "You pressed Win+Spacebar in Notepad or " MyWindowTitle
 #HotIf
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-autohotkey-plus-plus",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-autohotkey-plus-plus",
-            "version": "5.0.1",
+            "version": "5.0.2",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-autohotkey-plus-plus",
     "displayName": "AutoHotkey Plus Plus",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "description": "AutoHotkey v1 and v2 language support for Visual Studio Code: IntelliSense, debugging, formatting, and more",
     "categories": [
         "Programming Languages",


### PR DESCRIPTION
## 5.0.2 - 2023-08-10 🐈

-   Fix language mode resetting when VS Code restarts ([Issue #392](https://github.com/mark-wiemer-org/ahkpp/issues/392))