### PR TITLE
Fix extension crash when switching to nullish editor

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.3 - 2023-08-21 🏄
+
+-   Fix extension crash when switching to a nullish editor ([Issue #398](https://github.com/mark-wiemer-org/ahkpp/issues/398))
+
 ## 5.0.2 - 2023-08-10 🐈
 
 -   Fix language mode resetting when VS Code restarts ([Issue #392](https://github.com/mark-wiemer-org/ahkpp/issues/392))

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
     "version": "5.0.2",
     "description": "AutoHotkey v1 and v2 language support for Visual Studio Code: IntelliSense, debugging, formatting, and more",
     "categories": [
+        "Debuggers",
+        "Formatters",
         "Programming Languages",
-        "Snippets",
-        "Formatters"
+        "Snippets"
     ],
     "keywords": [
         "vscode",

--- a/src/service/languageVersionService.ts
+++ b/src/service/languageVersionService.ts
@@ -64,7 +64,7 @@ export const initializeLanguageVersionService = (
 ) => {
     const onSwitchFile = makeOnSwitchFile(new Set<vscode.Uri>());
     vscode.window.onDidChangeActiveTextEditor(
-        (newActiveEditor) => onSwitchFile(newActiveEditor.document),
+        (newActiveEditor) => onSwitchFile(newActiveEditor?.document),
         null,
         context.subscriptions,
     );


### PR DESCRIPTION
Closes #398.

Changes proposed in this pull request:

-   Fix extension crash when switching to a nullish editor
