### PR TITLE
v5.0.3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.3 - 2023-08-21 🏄
+
+-   Fix extension crash when switching to a nullish editor ([Issue #398](https://github.com/mark-wiemer-org/ahkpp/issues/398))
+
 ## 5.0.2 - 2023-08-10 🐈
 
 -   Fix language mode resetting when VS Code restarts ([Issue #392](https://github.com/mark-wiemer-org/ahkpp/issues/392))

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,6 @@
 
 -   `ahk++.file.interpreterPathV2` now defaults to `C:/Program Files/AutoHotkey/v2/AutoHotkey64.exe` ([Issue #387](https://github.com/mark-wiemer-org/ahkpp/issues/387))
 -   Add breakpoint support for AHK v2 files ([Issue #384](https://github.com/mark-wiemer-org/ahkpp/issues/384))
-<!-- -   Add AHK v2 debug config template ([Issue #385](https://github.com/mark-wiemer-org/ahkpp/issues/385)) -->
 
 ## 5.0.0 - 2023-08-07 ✌️
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-autohotkey-plus-plus",
-    "version": "5.0.2",
+    "version": "5.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-autohotkey-plus-plus",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-autohotkey-plus-plus",
     "displayName": "AutoHotkey Plus Plus",
-    "version": "5.0.2",
+    "version": "5.0.3",
     "description": "AutoHotkey v1 and v2 language support for Visual Studio Code: IntelliSense, debugging, formatting, and more",
     "categories": [
         "Programming Languages",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
     "version": "5.0.3",
     "description": "AutoHotkey v1 and v2 language support for Visual Studio Code: IntelliSense, debugging, formatting, and more",
     "categories": [
+        "Debuggers",
+        "Formatters",
         "Programming Languages",
-        "Snippets",
-        "Formatters"
+        "Snippets"
     ],
     "keywords": [
         "vscode",

--- a/src/service/languageVersionService.ts
+++ b/src/service/languageVersionService.ts
@@ -64,7 +64,7 @@ export const initializeLanguageVersionService = (
 ) => {
     const onSwitchFile = makeOnSwitchFile(new Set<vscode.Uri>());
     vscode.window.onDidChangeActiveTextEditor(
-        (newActiveEditor) => onSwitchFile(newActiveEditor.document),
+        (newActiveEditor) => onSwitchFile(newActiveEditor?.document),
         null,
         context.subscriptions,
     );


### PR DESCRIPTION
## 5.0.3 - 2023-08-21 🏄

-   Fix extension crash when switching to a nullish editor ([Issue #398](https://github.com/mark-wiemer-org/ahkpp/issues/398))