### PR TITLE
`FIX`: indent for single-line `hotkey` in fall-through scenario

### DIFF
--- a/src/providers/format.test.ts
+++ b/src/providers/format.test.ts
@@ -69,6 +69,7 @@ const formatTests: FormatTest[] = [
     { filenameRoot: '290-ifmsgbox' },
     { filenameRoot: '291-single-line-comment' },
     { filenameRoot: '316-if-object-continuation-section' },
+    { filenameRoot: '429-single-line-hotkey' },
     { filenameRoot: 'ahk-explorer' },
     { filenameRoot: 'align-assignment' },
     { filenameRoot: 'demo' },

--- a/src/providers/samples/429-single-line-hotkey.in.ahk
+++ b/src/providers/samples/429-single-line-hotkey.in.ahk
@@ -1,0 +1,16 @@
+; [Issue #429](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/429)
+#IfWinActive, WinTitle
+F1::
+F2::
+code
+return
+
+F1::
+F2:: foo()
+F3:: bar()
+
+F1::
+code
+F2:: foo()
+F3:: bar()
+#If

--- a/src/providers/samples/429-single-line-hotkey.out.ahk
+++ b/src/providers/samples/429-single-line-hotkey.out.ahk
@@ -1,0 +1,16 @@
+; [Issue #429](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/429)
+#IfWinActive, WinTitle
+    F1::
+    F2::
+        code
+    return
+
+    F1::
+    F2:: foo()
+    F3:: bar()
+
+    F1::
+        code
+    F2:: foo()
+    F3:: bar()
+#If


### PR DESCRIPTION
Closes #429.

Changes proposed in this pull request:

- add special check for single-line hotkey

Notifying @mark-wiemer
