### PR TITLE
`FIX`: `label` inside code block breaks `return` indentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
                 "ahk++.formatter.indentCodeAfterLabel": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Indent code after hotkey and label in not nested code block. Only applies to AHK v1."
+                    "description": "Indent code after hotkeys and labels in top-level code blocks. Only applies to AHK v1."
                 },
                 "ahk++.formatter.indentCodeAfterIfDirective": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
                 "ahk++.formatter.indentCodeAfterLabel": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Indent code after label. Only applies to AHK v1."
+                    "description": "Indent code after hotkey and label in not nested code block. Only applies to AHK v1."
                 },
                 "ahk++.formatter.indentCodeAfterIfDirective": {
                     "type": "boolean",

--- a/src/providers/format.test.ts
+++ b/src/providers/format.test.ts
@@ -69,6 +69,7 @@ const formatTests: FormatTest[] = [
     { filenameRoot: '290-ifmsgbox' },
     { filenameRoot: '291-single-line-comment' },
     { filenameRoot: '316-if-object-continuation-section' },
+    { filenameRoot: '432-label-inside-code-block' },
     { filenameRoot: 'ahk-explorer' },
     { filenameRoot: 'align-assignment' },
     { filenameRoot: 'demo' },

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -857,8 +857,11 @@ export const internalFormat = (
             if (indentCodeAfterLabel) {
                 // Label: or Hotkey:: <-- indent next line
                 //     code
-                depth++;
-                tagDepth = depth;
+                // Do this only if the LABEL is not inside a nested code
+                if (focDepth.depth.length === 1) {
+                    depth++;
+                    tagDepth = depth;
+                }
             }
         }
 

--- a/src/providers/samples/432-label-inside-code-block.in.ahk
+++ b/src/providers/samples/432-label-inside-code-block.in.ahk
@@ -1,0 +1,9 @@
+; [Issue #432](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/432)
+F1::
+if (var) {
+LABEL:
+code
+return
+}
+code
+return

--- a/src/providers/samples/432-label-inside-code-block.out.ahk
+++ b/src/providers/samples/432-label-inside-code-block.out.ahk
@@ -1,0 +1,9 @@
+; [Issue #432](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/432)
+F1::
+    if (var) {
+        LABEL:
+        code
+        return
+    }
+    code
+return

--- a/src/providers/samples/ahk-explorer.out.ahk
+++ b/src/providers/samples/ahk-explorer.out.ahk
@@ -2848,11 +2848,11 @@ ShellContextMenu(folderPath, files, win_hwnd = 0 )
     DllCall("GlobalFree", "Ptr", DllCall("SetWindowLongPtr", "Ptr", win_hwnd, "int", -4, "Ptr", WPOld,"UPtr"))
     DllCall("DestroyMenu", "Ptr", hMenu)
     StopContextMenu:
-        ObjRelease(pIContextMenu3)
-        ObjRelease(pIContextMenu2)
-        ObjRelease(pIContextMenu)
-        pIContextMenu2:=pIContextMenu3:=WPOld:=0
-        Gui,SHELL_CONTEXT:Destroy
+    ObjRelease(pIContextMenu3)
+    ObjRelease(pIContextMenu2)
+    ObjRelease(pIContextMenu)
+    pIContextMenu2:=pIContextMenu3:=WPOld:=0
+    Gui,SHELL_CONTEXT:Destroy
     return idn
 }
 WindowProc(hWnd, nMsg, wParam, lParam)


### PR DESCRIPTION
Closes #432.

Changes proposed in this pull request:

- make indent inside label only in top level code. No indent inside nested code blocks.
- change `ahk++.formatter.indentCodeAfterLabel` description in settings.

Indented code after `Hotkey` and `Label` needed only in top level hierarchy. Inside nested code blocks indent not needed. Optional behavior may be like in `Switch-Case` construction, where `Case CaseValue:` label has lower indent then code.

```autohotkey
Switch [SwitchValue]
{
Case CaseValue1: ; <-- lower indent
    Statements1
Case CaseValue2a, CaseValue2b:
    Statements2
Default:
    Statements3
}

```

Notifying @mark-wiemer
