### PR TITLE
Fixup npm audit issues and pipeline failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "@types/xml2js": "^0.4.11",
                 "@typescript-eslint/eslint-plugin": "^5.37.0",
                 "@typescript-eslint/parser": "^5.37.0",
-                "@vscode/test-electron": "^1.6.1",
+                "@vscode/test-electron": "^2.3.10",
                 "@vscode/vsce": "^2.20.1",
                 "chai": "^4.3.7",
                 "esbuild": "^0.15.7",
@@ -479,18 +479,18 @@
             "integrity": "sha512-64gY3PdU7jmYDwLRJFZ5XL2BC8TK5mdhZ60XLTZn17yfbJPKCcmFDuQAkVfOPsjn7o4f6YWFy3AXSR0V9gY6jA=="
         },
         "node_modules/@vscode/test-electron": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.2.tgz",
-            "integrity": "sha512-W01ajJEMx6223Y7J5yaajGjVs1QfW3YGkkOJHVKfAMEqNB1ZHN9wCcViehv5ZwVSSJnjhu6lYEYgwBdHtCxqhQ==",
+            "version": "2.3.10",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.10.tgz",
+            "integrity": "sha512-FxMqrvUm6a8S5tP4CymNJ40e6kD+wUTWTc6K32U629yrCCa+kl/rmpkC2gKpN4F4zjg1r+0Hnk9sl0+N2atsYA==",
             "dev": true,
             "dependencies": {
                 "http-proxy-agent": "^4.0.1",
                 "https-proxy-agent": "^5.0.0",
-                "rimraf": "^3.0.2",
-                "unzipper": "^0.10.11"
+                "jszip": "^3.10.1",
+                "semver": "^7.5.2"
             },
             "engines": {
-                "node": ">=8.9.3"
+                "node": ">=16"
             }
         },
         "node_modules/@vscode/vsce": {
@@ -811,28 +811,6 @@
             ],
             "optional": true
         },
-        "node_modules/big-integer": {
-            "version": "1.6.51",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/binary": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-            "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-            "dev": true,
-            "dependencies": {
-                "buffers": "~0.1.1",
-                "chainsaw": "~0.1.0"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -868,12 +846,6 @@
             "engines": {
                 "node": ">= 6"
             }
-        },
-        "node_modules/bluebird": {
-            "version": "3.4.7",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-            "dev": true
         },
         "node_modules/boolbase": {
             "version": "1.0.0",
@@ -949,24 +921,6 @@
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true
         },
-        "node_modules/buffer-indexof-polyfill": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/buffers": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.2.0"
-            }
-        },
         "node_modules/call-bind": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -1017,18 +971,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/chainsaw": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-            "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-            "dev": true,
-            "dependencies": {
-                "traverse": ">=0.3.0 <0.4"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/chalk": {
@@ -1506,15 +1448,6 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
-            }
-        },
-        "node_modules/duplexer2": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-            "dev": true,
-            "dependencies": {
-                "readable-stream": "^2.0.2"
             }
         },
         "node_modules/eastasianwidth": {
@@ -2359,33 +2292,6 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
-        "node_modules/fstream": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-            },
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/fstream/node_modules/rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
-        },
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2707,6 +2613,12 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+            "dev": true
+        },
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -2908,6 +2820,18 @@
                 "graceful-fs": "^4.1.6"
             }
         },
+        "node_modules/jszip": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+            "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+            "dev": true,
+            "dependencies": {
+                "lie": "~3.3.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "^1.0.5"
+            }
+        },
         "node_modules/keytar": {
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
@@ -2940,6 +2864,15 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/lie": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+            "dev": true,
+            "dependencies": {
+                "immediate": "~3.0.5"
             }
         },
         "node_modules/lilconfig": {
@@ -3007,12 +2940,6 @@
             "engines": {
                 "node": ">=16"
             }
-        },
-        "node_modules/listenercount": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-            "dev": true
         },
         "node_modules/listr2": {
             "version": "6.6.1",
@@ -3700,6 +3627,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "dev": true
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4011,9 +3944,9 @@
             }
         },
         "node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -4539,15 +4472,6 @@
                 "node": ">=8.0"
             }
         },
-        "node_modules/traverse": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-            "dev": true,
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/tsutils": {
             "version": "3.21.0",
             "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
@@ -4667,24 +4591,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/unzipper": {
-            "version": "0.10.11",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-            "dev": true,
-            "dependencies": {
-                "big-integer": "^1.6.17",
-                "binary": "~0.3.0",
-                "bluebird": "~3.4.1",
-                "buffer-indexof-polyfill": "~1.0.0",
-                "duplexer2": "~0.1.4",
-                "fstream": "^1.0.12",
-                "graceful-fs": "^4.2.2",
-                "listenercount": "~1.0.1",
-                "readable-stream": "~2.3.6",
-                "setimmediate": "~1.0.4"
             }
         },
         "node_modules/uri-js": {
@@ -5280,15 +5186,15 @@
             "integrity": "sha512-64gY3PdU7jmYDwLRJFZ5XL2BC8TK5mdhZ60XLTZn17yfbJPKCcmFDuQAkVfOPsjn7o4f6YWFy3AXSR0V9gY6jA=="
         },
         "@vscode/test-electron": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.2.tgz",
-            "integrity": "sha512-W01ajJEMx6223Y7J5yaajGjVs1QfW3YGkkOJHVKfAMEqNB1ZHN9wCcViehv5ZwVSSJnjhu6lYEYgwBdHtCxqhQ==",
+            "version": "2.3.10",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.10.tgz",
+            "integrity": "sha512-FxMqrvUm6a8S5tP4CymNJ40e6kD+wUTWTc6K32U629yrCCa+kl/rmpkC2gKpN4F4zjg1r+0Hnk9sl0+N2atsYA==",
             "dev": true,
             "requires": {
                 "http-proxy-agent": "^4.0.1",
                 "https-proxy-agent": "^5.0.0",
-                "rimraf": "^3.0.2",
-                "unzipper": "^0.10.11"
+                "jszip": "^3.10.1",
+                "semver": "^7.5.2"
             }
         },
         "@vscode/vsce": {
@@ -5523,22 +5429,6 @@
             "dev": true,
             "optional": true
         },
-        "big-integer": {
-            "version": "1.6.51",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-            "dev": true
-        },
-        "binary": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-            "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-            "dev": true,
-            "requires": {
-                "buffers": "~0.1.1",
-                "chainsaw": "~0.1.0"
-            }
-        },
         "binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -5570,12 +5460,6 @@
                     }
                 }
             }
-        },
-        "bluebird": {
-            "version": "3.4.7",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-            "dev": true
         },
         "boolbase": {
             "version": "1.0.0",
@@ -5631,18 +5515,6 @@
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true
         },
-        "buffer-indexof-polyfill": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-            "dev": true
-        },
-        "buffers": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-            "dev": true
-        },
         "call-bind": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -5678,15 +5550,6 @@
                 "loupe": "^2.3.1",
                 "pathval": "^1.1.1",
                 "type-detect": "^4.0.5"
-            }
-        },
-        "chainsaw": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-            "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-            "dev": true,
-            "requires": {
-                "traverse": ">=0.3.0 <0.4"
             }
         },
         "chalk": {
@@ -6026,15 +5889,6 @@
                 "dom-serializer": "^2.0.0",
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.1"
-            }
-        },
-        "duplexer2": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-            "dev": true,
-            "requires": {
-                "readable-stream": "^2.0.2"
             }
         },
         "eastasianwidth": {
@@ -6579,29 +6433,6 @@
             "dev": true,
             "optional": true
         },
-        "fstream": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-            },
-            "dependencies": {
-                "rimraf": {
-                    "version": "2.7.1",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                }
-            }
-        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -6817,6 +6648,12 @@
             "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
             "dev": true
         },
+        "immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+            "dev": true
+        },
         "import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -6971,6 +6808,18 @@
                 "universalify": "^2.0.0"
             }
         },
+        "jszip": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+            "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+            "dev": true,
+            "requires": {
+                "lie": "~3.3.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "^1.0.5"
+            }
+        },
         "keytar": {
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
@@ -6996,6 +6845,15 @@
             "requires": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
+            }
+        },
+        "lie": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+            "dev": true,
+            "requires": {
+                "immediate": "~3.0.5"
             }
         },
         "lilconfig": {
@@ -7044,12 +6902,6 @@
                     "dev": true
                 }
             }
-        },
-        "listenercount": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-            "dev": true
         },
         "listr2": {
             "version": "6.6.1",
@@ -7549,6 +7401,12 @@
                 "p-limit": "^3.0.2"
             }
         },
+        "pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "dev": true
+        },
         "parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7774,9 +7632,9 @@
             }
         },
         "readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
@@ -8145,12 +8003,6 @@
                 "is-number": "^7.0.0"
             }
         },
-        "traverse": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-            "dev": true
-        },
         "tsutils": {
             "version": "3.21.0",
             "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
@@ -8239,24 +8091,6 @@
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
             "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
             "dev": true
-        },
-        "unzipper": {
-            "version": "0.10.11",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-            "dev": true,
-            "requires": {
-                "big-integer": "^1.6.17",
-                "binary": "~0.3.0",
-                "bluebird": "~3.4.1",
-                "buffer-indexof-polyfill": "~1.0.0",
-                "duplexer2": "~0.1.4",
-                "fstream": "^1.0.12",
-                "graceful-fs": "^4.2.2",
-                "listenercount": "~1.0.1",
-                "readable-stream": "~2.3.6",
-                "setimmediate": "~1.0.4"
-            }
         },
         "uri-js": {
             "version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2402,9 +2402,9 @@
             }
         },
         "node_modules/get-func-name": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-            "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
             "dev": true,
             "engines": {
                 "node": "*"
@@ -3722,9 +3722,9 @@
             }
         },
         "node_modules/parse-semver/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver"
@@ -6615,9 +6615,9 @@
             "dev": true
         },
         "get-func-name": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-            "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
             "dev": true
         },
         "get-intrinsic": {
@@ -7568,9 +7568,9 @@
             },
             "dependencies": {
                 "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "version": "5.7.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+                    "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
                     "dev": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -506,7 +506,7 @@
         "@types/xml2js": "^0.4.11",
         "@typescript-eslint/eslint-plugin": "^5.37.0",
         "@typescript-eslint/parser": "^5.37.0",
-        "@vscode/test-electron": "^1.6.1",
+        "@vscode/test-electron": "^2.3.10",
         "@vscode/vsce": "^2.20.1",
         "chai": "^4.3.7",
         "esbuild": "^0.15.7",


### PR DESCRIPTION
- Address `npm audit` warnings by upgrading relevant packages
- Upgrade @vscode/test-electron to fix win32 archive issue (was occurring locally as well)