### PR TITLE
`FIX`: don't show not valid `LABEL` in `OUTLINE`

### DIFF
--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -38,6 +38,39 @@ suite('Parser', () => {
         });
     });
 
+    suite('getLabelByLine', () => {
+        // List of test data
+        const dataList = [
+            // {
+            //     in: // input test string
+            //     rs: // expected result - label name or undefined
+            // },
+            {
+                in: 'ValidLabel:',
+                rs: 'ValidLabel',
+            },
+            {
+                in: 'NotValidLabel :',
+                rs: undefined,
+            },
+        ];
+        dataList.forEach((data) => {
+            test("'" + data.in + "' => '" + data.rs + "'", async () => {
+                const document = await vscode.workspace.openTextDocument({
+                    language: 'ahk',
+                    content: data.in,
+                });
+                // Use array access for the private members
+                const label = Parser['getLabelByLine'](document, 0);
+                if (label === undefined) {
+                    assert.equal(label, data.rs);
+                } else {
+                    assert.strictEqual(label.name, data.rs);
+                }
+            });
+        });
+    });
+
     suite('getRemarkByLine', () => {
         // List of test data
         const dataList = [

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -223,7 +223,7 @@ export class Parser {
     private static getLabelByLine(document: vscode.TextDocument, line: number) {
         const text = CodeUtil.purify(document.lineAt(line).text);
         // [\u4e00-\u9fa5] Chinese unicode characters
-        const label = /^[ \t]*([\u4e00-\u9fa5_a-zA-Z0-9]+) *:{1}(?!(:|=))/.exec(
+        const label = /^[ \t]*([\u4e00-\u9fa5_a-zA-Z0-9]+):{1}(?!(:|=))/.exec(
             text,
         );
         if (label) {


### PR DESCRIPTION
Closes #438.

Changes proposed in this pull request:

- remove space before colon in parser's regexp for label

Notifying @mark-wiemer
