### PR TITLE
Fixes compile errors during test and registers the ahk2 type

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,37 +25,40 @@ export function activate(context: vscode.ExtensionContext) {
         Global.hide();
     })();
 
-    const language = { language: 'ahk' };
+    const languages = [{ language: 'ahk' }, { language: 'ahk2' }];
     FileManager.init(context);
     initializeLanguageVersionService(context);
     context.subscriptions.push(
         vscode.languages.registerHoverProvider(
-            language,
+            languages,
             new AhkHoverProvider(context),
         ),
         vscode.languages.registerDefinitionProvider(
-            language,
+            languages,
             new DefProvider(),
         ),
         vscode.languages.registerRenameProvider(
-            language,
+            languages,
             new AhkRenameProvider(),
         ),
         vscode.languages.registerSignatureHelpProvider(
-            language,
+            languages,
             new SignatureProvider(),
             '(',
             ',',
         ),
         vscode.languages.registerDocumentSymbolProvider(
-            language,
+            languages,
             new SymbolProvider(),
         ),
         vscode.languages.registerDocumentFormattingEditProvider(
-            language,
+            languages,
             new FormatProvider(),
         ),
-        vscode.languages.registerReferenceProvider(language, new RefProvider()),
+        vscode.languages.registerReferenceProvider(
+            languages,
+            new RefProvider(),
+        ),
         vscode.debug.registerDebugAdapterDescriptorFactory(
             'ahk',
             new InlineDebugAdapterFactory(),
@@ -80,7 +83,7 @@ export function activate(context: vscode.ExtensionContext) {
     if (Global.getConfig<boolean>(ConfigKey.enableIntellisense)) {
         context.subscriptions.push(
             vscode.languages.registerCompletionItemProvider(
-                language,
+                languages,
                 new CompletionProvider(),
                 '.',
             ),


### PR DESCRIPTION
Relates to [#413](https://github.com/mark-wiemer-org/ahkpp/issues/413). This and others are pointed to an issue recommending to change the file version, which is only a workaround for the underlying missing language type registration

Changes proposed in this pull request:

-   Register ahk2 during activation
- Add dependency and update tsconfig, without which project tests wouldn't compile

---

Notifying @mark-wiemer
