### PR TITLE
6.3.0 - 2024-10-19 🕳️

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.3.0 - unreleased 🕳️
+## 6.3.0 - 2024-10-19 🕳️
 
 ### New features
 

--- a/demos/manualTests/config.ahk2
+++ b/demos/manualTests/config.ahk2
@@ -2,8 +2,13 @@
 #Requires AutoHotkey v2.0
 #SingleInstance
 
+;** AHK++.exclude tested via automated tests :)
+; set AHK++.v2.general > librarySuggestions to All
+; set exclude to "excluded.ahk"
+; see whether MyExcludedFunc is suggested (Ctrl+Space)
+MyEx
 
-;* AHK++.general
+;** AHK++.general
 ;* showOutput
 ; always: shows on start
 ; never: never shows
@@ -12,31 +17,34 @@
 
 ; always
 ; never
-x := 1
+y := 1
 
 ; todo Completion Commit Characters (AHK++.v2.completionCommitCharacters) is untested for now
 
-;* AHK++.v2.diagnostics
+;** V2: Diagnostics (AHK++.v2.diagnostics)
 ; todo Class Non Dynamic Member Check is untested for now
 ; todo Params Check is untested for now
 
-; todo Exclude should work now ;)
+;** V2: Formatter tested in other files :)
 
-;* Comment Tag Regex (AHK++.v2.general)
+;** V2: General (AHK++.v2.general)
+
+;* commentTagRegex
 ; comments matching the regex show up in the command palette and breadcrumb
 ; Ctrl+Shift+O or F1 > "Go to Symbol in Editor"
 ;; hello world
 
-;* Complete Function Calls (AHK++.v2.general)
+;* completeFunctionCalls
 ; when typing a function name, the parens are automatically added
 ; cursor moved to the middle of the parens
 
-;* Library suggestions (AHK++.v2.general)
+;* librarySuggestions
 ; https://www.autohotkey.com/docs/v2/Scripts.htm#lib
 ; I added "MyMsgBox" to my standard library
 ; and "MyLocalMsgBox" to the local library
 
-;;* AHK++.v2.warn
+
+;** V2: Warn (AHK++.v2.warn)
 
 ;* callWithoutParentheses
 MyFunc

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-autohotkey-plus-plus",
-    "version": "6.2.3",
+    "version": "6.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-autohotkey-plus-plus",
-            "version": "6.2.3",
+            "version": "6.3.0",
             "license": "See license.md",
             "dependencies": {
                 "@vscode/debugadapter": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-autohotkey-plus-plus",
     "displayName": "AHK++ (AutoHotkey Plus Plus)",
-    "version": "6.2.3",
+    "version": "6.3.0",
     "description": "AutoHotkey v1 and v2 language support for Visual Studio Code: IntelliSense, debugging, formatting, and more!",
     "categories": [
         "Debuggers",

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -35,9 +35,9 @@ export class Parser {
             excludeConfig,
             Out.debug,
         );
-        Out.log(`Building ${paths.length} files`);
+        Out.debug(`Building ${paths.length} files`);
         for (const path of paths) {
-            Out.log(`Building ${path}`);
+            Out.debug(`Building ${path}`);
             const document = await vscode.workspace.openTextDocument(
                 vscode.Uri.file(path),
             );


### PR DESCRIPTION
### New features

-   Rewrite AutoHotkey v2 definition files using [GroggyOtter](https://github.com/GroggyOtter/ahkv2_definition_rewrite)'s syntaxes ([#521](https://github.com/mark-wiemer-org/ahkpp/issues/521))
-   Add exclude setting ([#488](https://github.com/mark-wiemer-org/ahkpp/issues/488))
    -   Excluded files are not included in IntelliSense completion suggestions, even when they're added via `#include`
    -   Changed `v2.exclude` setting to `exclude`
    -   One setting works for both v1 and v2
    -   Changes to this setting take effect immediately, no need to restart your IDE (different than thqby's extension)
    -   v2 will exclude excluded files from suggestions even if they're opened in the IDE (different than thqby's extension)
    -   v1 no longer automatically ignores files with `out`, `target`, or `node_modules` in their name

### Fixes

-   Fix v1 formatter removing extra spaces in strings ([#411](https://github.com/mark-wiemer-org/ahkpp/issues/411))
-   Fix v2 formatter moving closing brackets/braces when `arrayStyle` or `objectStyle` were set to "none" (the default) ([#499](https://github.com/mark-wiemer-org/ahkpp/issues/499))
-   Fixup output channel names: "AHK++ (v1)" and "AHK++ (v2)" instead of "AHK" and "AHK++" respectively
-   Fix duplicate output channels (the "AHK" channel used to be created twice)

### Other

-   Rename extension to `AHK++ (AutoHotkey Plus Plus)` to provide a clear short name while retaining previous brand
    -   In 6.2.0, only the settings were renamed. This release renames the extension display name on registries as well.