### PR TITLE
Merge thqby 2.5.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,17 @@
 
 ## 6.4.0 - unreleased
 
+-   Update thqby's extension from 2.5.3 to 2.5.4, adding new bugfixes
+
 ### New features
 
 -   Hovering over a filename in an `#include` directive now provides a link to that document in your IDE
+
+### Bugfixes
+
+-   Improve "go to definition" in v2 files ([thqby #610](https://github.com/thqby/vscode-autohotkey2-lsp/issues/610))
+-   Improve environment variables when debugging via IDE for parity with running outside of IDE ([thqby #615](https://github.com/thqby/vscode-autohotkey2-lsp/issues/615))
+-   Add hover tip for `switch` keyword in v2 files ([thqby #623](https://github.com/thqby/vscode-autohotkey2-lsp/issues/623))
 
 ## 6.3.0 - 2024-10-19 🕳️
 

--- a/language/language-configuration.json
+++ b/language/language-configuration.json
@@ -1,3 +1,5 @@
+// ahk2 language configuration from thqby
+// used under GNU LGPL v3
 {
     "comments": {
         "lineComment": ";",
@@ -38,6 +40,12 @@
         ["'", "'"],
         ["%", "%"]
     ],
+    "folding": {
+        "markers": {
+            "start": "^\\s*;\\s*@region\\b",
+            "end": "^\\s*;\\s*@endregion\\b"
+        }
+    },
     "indentationRules": {
         "increaseIndentPattern": "^((?!;).)*(\\{[^}\"'`]*|\\([^)\"'`]*|\\[[^\\]\"'`]*)$",
         "decreaseIndentPattern": "^((?!.*?/\\*).*\\*/)?\\s*[\\])}].*$",

--- a/package.json
+++ b/package.json
@@ -1004,7 +1004,7 @@
                     ".ah2",
                     ".ahk2"
                 ],
-                "configuration": "./language/ahk2.configuration.json",
+                "configuration": "./language/language-configuration.json",
                 "icon": {
                     "dark": "./language/autohotkey2.svg",
                     "light": "./language/autohotkey2.svg"


### PR DESCRIPTION
-   Improve "go to definition" in v2 files ([thqby #610](https://github.com/thqby/vscode-autohotkey2-lsp/issues/610))
-   Improve environment variables when debugging via IDE for parity with running outside of IDE ([thqby #615](https://github.com/thqby/vscode-autohotkey2-lsp/issues/615))
-   Add hover tip for `switch` keyword in v2 files ([thqby #623](https://github.com/thqby/vscode-autohotkey2-lsp/issues/623))