### PR TITLE
6.4.0 🗳️

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,18 +1,19 @@
 # Changelog
 
-## 6.4.0 - unreleased
-
--   Update thqby's extension from 2.5.3 to 2.5.4, adding new bugfixes
+## 6.4.0 - 2024-11-02 🗳️
 
 ### New features
 
 -   Hovering over a filename in an `#include` directive now provides a link to that document in your IDE
+    -   If the file doesn't exist, the underline doesn't appear
+    -   Does not work for `#include <lib>` syntax yet.
 
 ### Bugfixes
 
--   Improve "go to definition" in v2 files ([thqby #610](https://github.com/thqby/vscode-autohotkey2-lsp/issues/610))
--   Improve environment variables when debugging via IDE for parity with running outside of IDE ([thqby #615](https://github.com/thqby/vscode-autohotkey2-lsp/issues/615))
--   Add hover tip for `switch` keyword in v2 files ([thqby #623](https://github.com/thqby/vscode-autohotkey2-lsp/issues/623))
+-   Update thqby's extension from 2.5.3 to 2.5.4, adding new bugfixes
+    -   Improve "go to definition" in v2 files ([thqby #610](https://github.com/thqby/vscode-autohotkey2-lsp/issues/610))
+    -   Improve environment variables when debugging via IDE for parity with running outside of IDE ([thqby #615](https://github.com/thqby/vscode-autohotkey2-lsp/issues/615))
+    -   Add hover tip for `switch` keyword in v2 files ([thqby #623](https://github.com/thqby/vscode-autohotkey2-lsp/issues/623))
 
 ## 6.3.0 - 2024-10-19 🕳️
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-autohotkey-plus-plus",
-    "version": "6.3.0",
+    "version": "6.4.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-autohotkey-plus-plus",
-            "version": "6.3.0",
+            "version": "6.4.0",
             "license": "See license.md",
             "dependencies": {
                 "@vscode/debugadapter": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-autohotkey-plus-plus",
     "displayName": "AHK++ (AutoHotkey Plus Plus)",
-    "version": "6.3.0",
+    "version": "6.4.0",
     "description": "AutoHotkey v1 and v2 language support for Visual Studio Code: IntelliSense, debugging, formatting, and more!",
     "categories": [
         "Debuggers",


### PR DESCRIPTION
### New features

-   Hovering over a filename in an `#include` directive now provides a link to that document in your IDE
    -   If the file doesn't exist, the underline doesn't appear
    -   Does not work for `#include <lib>` syntax yet.

### Bugfixes

-   Update thqby's extension from 2.5.3 to 2.5.4, adding new bugfixes
    -   Improve "go to definition" in v2 files ([thqby #610](https://github.com/thqby/vscode-autohotkey2-lsp/issues/610))
    -   Improve environment variables when debugging via IDE for parity with running outside of IDE ([thqby #615](https://github.com/thqby/vscode-autohotkey2-lsp/issues/615))
    -   Add hover tip for `switch` keyword in v2 files ([thqby #623](https://github.com/thqby/vscode-autohotkey2-lsp/issues/623))