### PR TITLE
Fix quick pick for "... does not exist" err, cleanup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report--non-formatter-.md
+++ b/.github/ISSUE_TEMPLATE/bug-report--non-formatter-.md
@@ -8,7 +8,7 @@ labels: bug
 assignees: mark-wiemer
 ---
 
-For troubleshooting assistance, refer to the [troubleshooting guide](../../docs/Troubleshooting.md)
+For troubleshooting assistance, refer to the [troubleshooting guide](https://github.com/mark-wiemer-org/docs/Troubleshooting.md)
 
 ## Description
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,8 +8,8 @@
     -   This has been moved to a console log visible in the AHK++ (v2) output channel
     -   A similar error message will still appear when attempting to debug with an unrecognized interpreter path
     -   See the new [troubleshooting guide](docs/Troubleshooting.md) for details
--   Fix quick pick not working for "... does not exist" error message on run AHK v2 script
-    > Note: this fix copies your config into your workspace settings. If you don't like this, please manually enter the path via the settings, and don't use the quick pick. Learn more at the linked PR
+-   Fix quick pick for "... does not exist" error message on run AHK v2 script ([PR #569](https://github.com/mark-wiemer-org/ahkpp/issues/569))
+    > Note: this fix copies your config into your workspace settings. If you don't like this, please manually enter the path via the settings, and don't use the quick pick. Learn more at [PR #569](https://github.com/mark-wiemer-org/ahkpp/issues/569).
 
 ## 6.4.0 - 2024-11-02 🗳️
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@
     -   This has been moved to a console log visible in the AHK++ (v2) output channel
     -   A similar error message will still appear when attempting to debug with an unrecognized interpreter path
     -   See the new [troubleshooting guide](docs/Troubleshooting.md) for details
+-   Fix quick pick not working for "... does not exist" error message on run AHK v2 script
+    > Note: this fix copies your config into your workspace settings. If you don't like this, please manually enter the path via the settings, and don't use the quick pick. Learn more at the linked PR
 
 ## 6.4.0 - 2024-11-02 🗳️
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,12 +2,18 @@
 
 ## 6.4.1 - unreleased 🛠️
 
+### Known issues
+
+-   If your AHK v2 interpreter is not recognized and you try to debug an AHK v2 script, an "AutoHotkey execute bin not found: ..." output log will appear and take focus in the AHK++ (v1) output channel (open issue [#570](https://github.com/mark-wiemer-org/ahkpp/issues/570))
+-   The "Select AHK v2 interpreter" command does not work, instead please try to run (not debug) an AHK v2 script and use the quick pick from the "... does not exist" error message (open issue [#571](https://github.com/mark-wiemer-org/ahkpp/issues/571))
+
+### Fixes
+
 -   Add [troubleshooting guide](docs/Troubleshooting.md)
 -   Fix go to definition in AHK v1 files ([#559](https://github.com/mark-wiemer-org/ahkpp/issues/559))
 -   Remove unnecessary error message "Couldn't resolve AHK v2 interpreter" ([#493](https://github.com/mark-wiemer-org/ahkpp/issues/493))
-    -   This has been moved to a console log visible in the AHK++ (v2) output channel
-    -   A similar error message will still appear when attempting to debug with an unrecognized interpreter path
-    -   See the new [troubleshooting guide](docs/Troubleshooting.md) for details
+    -   This has been moved to a output log visible in the AHK++ (v2) output channel
+    -   A "... does not exist" error message will still appear when trying to run an AHK v2 script with an unrecognized interpreter path
 -   Fix quick pick for "... does not exist" error message on run AHK v2 script ([PR #569](https://github.com/mark-wiemer-org/ahkpp/issues/569))
     > Note: this fix copies your config into your workspace settings. If you don't like this, please manually enter the path via the settings, and don't use the quick pick. Learn more at [PR #569](https://github.com/mark-wiemer-org/ahkpp/issues/569).
 

--- a/demos/manualTests/bugfixes.ahk
+++ b/demos/manualTests/bugfixes.ahk
@@ -1,26 +1,26 @@
 ;* Formatting should not change this file
-; By default no action needed, older versions would show warnings or errors
+;* By default no action needed, older versions would show warnings or errors
 #Requires AutoHotkey v2.0
 
-;* https://github.com/thqby/vscode-autohotkey2-lsp/issues/591
+; https://github.com/thqby/vscode-autohotkey2-lsp/issues/591
 TraySetIcon(, , true)
 
-;* https://github.com/thqby/vscode-autohotkey2-lsp/issues/594
+; https://github.com/thqby/vscode-autohotkey2-lsp/issues/594
 class Test {
     __New() {
         1 ? this.b := 1 : 0
     }
 }
 
-;* https://github.com/thqby/vscode-autohotkey2-lsp/issues/595
-; Should suggest `ptr` as second arg (Ctrl+Space)
+; https://github.com/thqby/vscode-autohotkey2-lsp/issues/595
+;* Should suggest `ptr` as second arg (Ctrl+Space)
 DllCall.Bind("xx", "p")
 
-;* https://github.com/thqby/vscode-autohotkey2-lsp/issues/596
+; https://github.com/thqby/vscode-autohotkey2-lsp/issues/596
 Help:: return
 Sleep:: return
 
-;* https://github.com/thqby/vscode-autohotkey2-lsp/issues/574
+; https://github.com/thqby/vscode-autohotkey2-lsp/issues/574
 if 1 {
     f() {
         MsgBox("in")
@@ -28,11 +28,11 @@ if 1 {
     MsgBox("out")
 }
 
-;* https://github.com/thqby/vscode-autohotkey2-lsp/issues/571
-class class2
-{
+; https://github.com/thqby/vscode-autohotkey2-lsp/issues/571
+class class2 {
     __New() {
         this.g := Gui()
-        this.g.add() ; hover over add to see tooltip
+        ;* hover over `add` to see tooltip
+        this.g.add()
     }
 }

--- a/demos/manualTests/config.ahk2
+++ b/demos/manualTests/config.ahk2
@@ -25,6 +25,17 @@ y := 1
 ; todo Class Non Dynamic Member Check is untested for now
 ; todo Params Check is untested for now
 
+;** V2: File (AHK++.v2.file)
+;* interpreterPath
+; Setting to an invalid path and restarting the extension host should:
+; - not show an error message on startup
+; - add msg to output channel: Ctrl+Shift+U -> AHK++ (v2) -> "Couldn't resolve AHK v2 interpreter"
+; - show "Select AHK v2 Interpreter" in status bar
+; - show error message when trying to run a script
+; - log error message in AHK++ (v1) when trying to debug a script
+; - update when user confirms quick pick via error message
+; - successfully run a script when user confirms quick pick
+
 ;** V2: Formatter tested in other files :)
 
 ;** V2: General (AHK++.v2.general)

--- a/demos/manualTests/config.ahk2
+++ b/demos/manualTests/config.ahk2
@@ -33,7 +33,7 @@ y := 1
 ; - show "Select AHK v2 Interpreter" in status bar
 ; - show error message when trying to run a script
 ; - log error message in AHK++ (v1) when trying to debug a script
-; - update when user confirms quick pick via error message
+; - persist settings when user confirms quick pick via error message
 ; - successfully run a script when user confirms quick pick
 
 ;** V2: Formatter tested in other files :)

--- a/demos/manualTests/config.ahk2
+++ b/demos/manualTests/config.ahk2
@@ -6,7 +6,7 @@
 ; set AHK++.v2.general > librarySuggestions to All
 ; set exclude to "excluded.ahk"
 ; see whether MyExcludedFunc is suggested (Ctrl+Space)
-MyEx
+MyExclu
 
 ;** AHK++.general
 ;* showOutput

--- a/demos/manualTests/format/formatter.ahk1
+++ b/demos/manualTests/format/formatter.ahk1
@@ -10,4 +10,4 @@
 
 ; How many were preserved? ;)
 
-; todo other options not tested
+; todo other options not manually tested

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -6,7 +6,10 @@ If AHK++ isn't behaving as you expect, here are some things you can try.
 
 For AHK v2, the language server may not behave correctly if it fails to identify a valid path to an interpreter like `AutoHotkey.exe`. The status bar at the bottom left of your IDE should show the current interpreter or an option to "Select AHK v2 Interpreter".
 
-Currently, AHK++ does not support the Windows Store edition of AHK v2, but there are plans to support it by the end of 2024, ref [#496](https://github.com/mark-wiemer-org/ahkpp/issues/496).
+> Currently, the "Select AHK v2 Interpreter" command does not work, ref [#571](https://github.com/mark-wiemer-org/ahkpp/issues/571).
+> To ensure the extension fully recognizes your interpreter, try to run (not debug) an AHK v2 script. If you get a "... does not exist" error message, the corresponding quick pick will work.
+
+> Currently, AHK++ does not support the Windows Store edition of AHK v2, but there are plans to support it by the end of 2024, ref [#496](https://github.com/mark-wiemer-org/ahkpp/issues/496).
 
 Interpreter found:
 

--- a/src/debugger/debugDispatcher.ts
+++ b/src/debugger/debugDispatcher.ts
@@ -101,6 +101,7 @@ export class DebugDispatcher extends EventEmitter {
         const programName = getFileNameOnly(args.program);
 
         if (!existsSync(runtime)) {
+            // Exact text is referenced in docs, update docs when updating this value
             Out.log(`AutoHotkey execute bin not found: ${runtime}`);
             this.end();
             return;


### PR DESCRIPTION
To persist settings, we have to persist an entire object. That's why it wasn't working before. However, it doesn't seem trivial to fetch only the workspace config, we have to fetch the entire config (workspace, user, global). We don't know which properties came from which target by default, so for now we are pasting the entire config into workspace settings.

In the future, we could iterate through each property of the fetched object, find its configuration target (as ahk2/src/extension.ts already does), and only paste the workspace settings into, well, the workspace settings.

Quick pick fix is entirely in ahk2, other changes here are:
- changelog cleanup
- manual tests updates
- troubleshooting guide updates
- bug report template updates