### PR TITLE
v6.4.1 🛠️

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.4.1 - unreleased 🛠️
+## 6.4.1 - 2024-11-09 🛠️
 
 ### Known issues
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-autohotkey-plus-plus",
-    "version": "6.4.0",
+    "version": "6.4.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-autohotkey-plus-plus",
-            "version": "6.4.0",
+            "version": "6.4.1",
             "license": "See license.md",
             "dependencies": {
                 "@vscode/debugadapter": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-autohotkey-plus-plus",
     "displayName": "AHK++ (AutoHotkey Plus Plus)",
-    "version": "6.4.0",
+    "version": "6.4.1",
     "description": "AutoHotkey v1 and v2 language support for Visual Studio Code: IntelliSense, debugging, formatting, and more!",
     "categories": [
         "Debuggers",


### PR DESCRIPTION
### Known issues

-   If your AHK v2 interpreter is not recognized and you try to debug an AHK v2 script, an "AutoHotkey execute bin not found: ..." output log will appear and take focus in the AHK++ (v1) output channel (open issue [#570](https://github.com/mark-wiemer-org/ahkpp/issues/570))
-   The "Select AHK v2 interpreter" command does not work, instead please try to run (not debug) an AHK v2 script and use the quick pick from the "... does not exist" error message (open issue [#571](https://github.com/mark-wiemer-org/ahkpp/issues/571))

### Fixes

-   Add [troubleshooting guide](docs/Troubleshooting.md)
-   Fix go to definition in AHK v1 files ([#559](https://github.com/mark-wiemer-org/ahkpp/issues/559))
-   Remove unnecessary error message "Couldn't resolve AHK v2 interpreter" ([#493](https://github.com/mark-wiemer-org/ahkpp/issues/493))
    -   This has been moved to a output log visible in the AHK++ (v2) output channel
    -   A "... does not exist" error message will still appear when trying to run an AHK v2 script with an unrecognized interpreter path
-   Fix quick pick for "... does not exist" error message on run AHK v2 script ([PR #569](https://github.com/mark-wiemer-org/ahkpp/issues/569))
    > Note: this fix copies your config into your workspace settings. If you don't like this, please manually enter the path via the settings, and don't use the quick pick. Learn more at [PR #569](https://github.com/mark-wiemer-org/ahkpp/issues/569).