### PR TITLE
v6.4.2 - 2024-12-16 🎄

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.4.2 - 2024-12-16 🎄
+
+-   Reduce required VS Code version to 1.68 (#574)
+-   Update internal dependencies for security (#577)
+
 ## 6.4.1 - 2024-11-09 🛠️
 
 ### Known issues

--- a/demos/manualTests/commands.ahk2
+++ b/demos/manualTests/commands.ahk2
@@ -8,14 +8,14 @@
 
 ;* Export AHK Symbols should give ~45 lines for this
 ; And open in an unsaved new editor group
-MyMsgBox(text) {
+MyCommandMsgBox(text) {
     MsgBox(text)
 }
 
 ;* Stop AHK Script should work after starting via Run AHK Script
 ; Auto-closes MsgBox windows as well :)
-MyMsgBox("Hello world!")
-MyMsgBox("Hello again!")
+MyCommandMsgBox("Hello world!")
+MyCommandMsgBox("Hello again!")
 
 ;* Add Doc Comment should add and then go to doc comment
 ; todo Known issue with two args will be reported later

--- a/demos/manualTests/config.ahk2
+++ b/demos/manualTests/config.ahk2
@@ -4,24 +4,16 @@
 
 ;** AHK++.exclude tested via automated tests :)
 ; set AHK++.v2.general > librarySuggestions to All
-; set exclude to "excluded.ahk"
+; set AHK++.exclude to "excluded.ahk"
 ; see whether MyExcludedFunc is suggested (Ctrl+Space)
 MyExclu
 
 ;** AHK++.general
-;* showOutput
-; always: shows on start
-; never: never shows
-; works only for running scripts
-; running: output is in the Output view
-
-; always
-; never
-y := 1
+;* showOutput (tested via e2e tests)
 
 ; todo Completion Commit Characters (AHK++.v2.completionCommitCharacters) is untested for now
 
-;** V2: Diagnostics (AHK++.v2.diagnostics)
+; todo ** V2: Diagnostics (AHK++.v2.diagnostics)
 ; todo Class Non Dynamic Member Check is untested for now
 ; todo Params Check is untested for now
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-autohotkey-plus-plus",
-    "version": "6.4.1",
+    "version": "6.4.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-autohotkey-plus-plus",
-            "version": "6.4.1",
+            "version": "6.4.2",
             "license": "See license.md",
             "dependencies": {
                 "@vscode/debugadapter": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-autohotkey-plus-plus",
     "displayName": "AHK++ (AutoHotkey Plus Plus)",
-    "version": "6.4.1",
+    "version": "6.4.2",
     "description": "AutoHotkey v1 and v2 language support for Visual Studio Code: IntelliSense, debugging, formatting, and more!",
     "categories": [
         "Debuggers",


### PR DESCRIPTION
-   Reduce required VS Code version to 1.68 (#574)
-   Update internal dependencies for security (#577)